### PR TITLE
Feat/data import FuE chart and shares chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,9 @@ __pycache__/
 **/.DS_Store
 **/.db
 .python-version
+
 node_modules
 .vscode
+
+/data
+

--- a/app/locales/de.json
+++ b/app/locales/de.json
@@ -28,22 +28,37 @@
   "sections": [
     {
       "id": "section_1",
-      "title": "Erhebung 1",
+      "title": "Basisdaten",
       "sectionDescription": "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Assumenda soluta sed consequatur rem saepe dolores voluptates recusandae explicabo officiis",
       "toggleText": "Zusammensetzung der FuE-Ausgaben in ",
-      "chart-ids": ["base_chart_ber", "base_chart_ger"]
+      "chart-ids": [
+        "base_chart_ber",
+        "base_chart_ger"
+      ]
     },
     {
       "id": "section_2",
-      "title": "Erhebung 2",
+      "title": "FuE-Ausgaben",
       "sectionDescription": "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Assumenda soluta sed consequatur rem saepe dolores voluptates recusandae explicabo officiis",
-      "chart-ids": ["pizza_chart"]
+      "chart-ids": [
+        "fue_chart"
+      ]
     },
     {
       "id": "section_3",
+      "title": "Anteile-Ausgaben",
+      "sectionDescription": "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Assumenda soluta sed consequatur rem saepe dolores voluptates recusandae explicabo officiis",
+      "chart-ids": [
+        "shares_chart"
+      ]
+    },
+    {
+      "id": "section_4",
       "title": "Erhebung 3",
       "sectionDescription": "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Assumenda soluta sed consequatur rem saepe dolores voluptates recusandae explicabo officiis",
-      "chart-ids": ["funky_bubble_chart"]
+      "chart-ids": [
+        "funky_bubble_chart"
+      ]
     }
   ]
 }

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.gzip import GZipMiddleware
 import panel as pn
-from sliders.pn_app import get_base_chart, get_base_chart_ger, get_base_chart_ber, get_funky_bubble_chart, get_pizza_chart, create_app
+from sliders.pn_app import get_base_chart, get_base_chart_ger, get_base_chart_ber, get_funky_bubble_chart, get_fue_chart, get_shares_chart
 from utils.translation import load_translation
 from enum import Enum
 import logging
@@ -28,7 +28,8 @@ async def bkapp_page(request: Request, language: Language = None):
     # translations = load_translation(language)
     translations = load_translation("de")
 
-    request.app.extra["pizza_chart"] = server_document('http://127.0.0.1:5000/pizza_chart')
+    request.app.extra["fue_chart"] = server_document('http://127.0.0.1:5000/fue_chart')
+    request.app.extra["shares_chart"] = server_document('http://127.0.0.1:5000/shares_chart')
     request.app.extra["base_chart"] = server_document('http://127.0.0.1:5000/base_chart')
     request.app.extra["base_chart_ger"] = server_document('http://127.0.0.1:5000/base_chart_ger')
     request.app.extra["base_chart_ber"] = server_document('http://127.0.0.1:5000/base_chart_ber')
@@ -40,8 +41,8 @@ async def bkapp_page(request: Request, language: Language = None):
 
 
 pn.serve({
-    '/app': create_app, 
-    '/pizza_chart': get_pizza_chart, 
+    '/fue_chart': get_fue_chart, 
+    '/shares_chart': get_shares_chart, 
     '/base_chart': get_base_chart, 
     '/base_chart_ger': get_base_chart_ger,
     '/base_chart_ber': get_base_chart_ber,

--- a/app/sliders/config_custom.yaml
+++ b/app/sliders/config_custom.yaml
@@ -76,11 +76,11 @@ pie_custom:
     - de
   filters:
     single_choice:
-      - "2010"
+      - "2011"
       - "2020"
-    single_choice_default: "2010"
+    single_choice_default: "2011"
     single_choice_highlight:
-      - wirtschaft
-      - hochschulen
-      - staat
-    single_choice_highlight_default: wirtschaft
+      - Wirtschaft
+      - Hochschulen
+      - Staat
+    single_choice_highlight_default: Wirtschaft

--- a/app/sliders/config_custom.yaml
+++ b/app/sliders/config_custom.yaml
@@ -69,7 +69,25 @@ basis_custom:
       - nahrung
       - pharma
 
-pie_custom:
+donut_shares:
+  plot_type: pie_interactive
+  plot_codes:
+    - ber
+    - de
+  filters:
+    single_choice:
+      - "2012"
+      - "2021"
+    single_choice_default: "2012"
+    single_choice_highlight:
+      - Maschinen-/Fahrzeugbau
+      - Elektroindustrie/Instrumententechnik
+      - Pharma/Chemie/Kunststoff
+      - Software/Datenverarbeitung
+      - restliche Branchen
+    single_choice_highlight_default: Maschinen-/Fahrzeugbau
+
+donut_fue:
   plot_type: pie_interactive
   plot_codes:
     - ber
@@ -84,3 +102,4 @@ pie_custom:
       - Hochschulen
       - Staat
     single_choice_highlight_default: Wirtschaft
+

--- a/app/sliders/config_importer.py
+++ b/app/sliders/config_importer.py
@@ -1,0 +1,57 @@
+import os
+import yaml
+
+class ConfigImporter:
+    def get_config(self):
+        """
+        Create a config dictionary based on default and custom values.
+
+        :return: dict, resulting configuration file
+        """
+        # Load config files
+        config_default = self.load_config_file("config_default.yaml")
+        config_custom = self.load_config_file("config_custom.yaml")
+
+        config_result = {}
+        # Override default values with custom values for each plot
+        for plot_name in config_custom:
+            plot_config_custom = config_custom[plot_name]
+            plot_type = plot_config_custom["plot_type"]
+            plot_config_default = config_default[plot_type]
+
+            overwritten_config = self.override_values(plot_config_default, plot_config_custom)
+            config_result[plot_name] = overwritten_config
+
+        return config_result
+
+    def load_config_file(self, filename):
+        """
+        Load a config file.
+
+        :param filename: str, name of the YAML config file
+        :return: dict, containing config settings
+        """
+        current_dir = os.path.dirname(__file__)
+        config_path = os.path.join(current_dir, filename)
+
+        with open(config_path, "r") as f:
+            config = yaml.load(f, Loader=yaml.FullLoader)
+
+        return config
+
+    def override_values(self, default_config, custom_config):
+        """
+        Override default values with custom values of a plot configuration.
+        Implemented as a recursive function.
+
+        :param default_config: dict, default configuration for a plot type
+        :param custom_config: dict, custom configuration for a plot
+        """
+
+        overwritten_config = default_config.copy()
+        for key, value in custom_config.items():
+            if isinstance(value, dict) and key in overwritten_config and isinstance(default_config[key], dict):
+                self.override_values(overwritten_config[key], value)
+            else:
+                overwritten_config[key] = value
+        return overwritten_config

--- a/app/sliders/mapping.py
+++ b/app/sliders/mapping.py
@@ -46,9 +46,3 @@ mapping_units = {
     "Innovations-ausgaben in Mio. €": "innovations_ausgaben_mio",
     "FuE-Ausgaben in Mio. €": "fue_ausgaben_mio",
 }
-
-mapping_fue = [
-  "Wirtschaft",
-  "Hochschulen",
-  "Staat",
-]

--- a/app/sliders/mapping.py
+++ b/app/sliders/mapping.py
@@ -46,3 +46,9 @@ mapping_units = {
     "Innovations-ausgaben in Mio. €": "innovations_ausgaben_mio",
     "FuE-Ausgaben in Mio. €": "fue_ausgaben_mio",
 }
+
+mapping_fue = [
+  "Wirtschaft",
+  "Hochschulen",
+  "Staat",
+]

--- a/app/sliders/plotter.py
+++ b/app/sliders/plotter.py
@@ -278,7 +278,6 @@ class InteractivePiePlotter(InteractivePlotter):
 
     def fit_data(self):
         self.fitted_data = {}
-        logging.info(f"Interactive plotter created: {self.config}")
 
         for code in self.config["plot_codes"]:
             # Extract data using the single choice filters

--- a/app/sliders/plotter.py
+++ b/app/sliders/plotter.py
@@ -7,6 +7,9 @@ from bokeh.plotting import figure
 from bokeh.transform import cumsum, linear_cmap
 import panel
 
+import logging
+logging.basicConfig(level=logging.INFO)
+
 PLOT_TYPES = {
     "bar": "BarPlotter",
     "bubble": "BubblePlotter",
@@ -275,6 +278,7 @@ class InteractivePiePlotter(InteractivePlotter):
 
     def fit_data(self):
         self.fitted_data = {}
+        logging.info(f"Interactive plotter created: {self.config}")
 
         for code in self.config["plot_codes"]:
             # Extract data using the single choice filters

--- a/app/sliders/pn_app.py
+++ b/app/sliders/pn_app.py
@@ -6,6 +6,8 @@ from panel.layout.gridstack import GridSpec
 from panel.layout.flex import FlexBox
 
 from .plotter import PlotterFactory
+# import logging
+# logging.basicConfig(level=logging.INFO)
 
 
 # Create some random data - TODO: To be deleted later
@@ -68,28 +70,76 @@ pie_data_2 = {
       }
     }
   }
-# pie_data_2 = {
-#     "ber": {
-#         "2010": {
-#             "x": ["wirtschaft", "hochschulen", "staat"],
-#             "y": [952, 380, 803]
-#         },
-#         "2020": {
-#             "x": ["wirtschaft", "hochschulen", "staat"],
-#             "y": [552, 280, 703]
-#         },
-#     },
-#     "de": {
-#         "2010": {
-#             "x": ["wirtschaft", "hochschulen", "staat"],
-#             "y": [1952, 1380, 1803]
-#         },
-#         "2020": {
-#             "x": ["wirtschaft", "hochschulen", "staat"],
-#             "y": [1552, 1280, 1703]
-#         },
-#     },
-# }
+shares_data = {
+    "ber": {
+      "2012": {
+        "x": [
+          "Maschinen-/Fahrzeugbau",
+          "Elektroindustrie/Instrumententechnik",
+          "Pharma/Chemie/Kunststoff",
+          "Software/Datenverarbeitung",
+          "restliche Branchen"
+        ],
+        "y": [
+          14.1,
+          30.4,
+          31.0,
+          7.2,
+          31.4
+        ]
+      },
+      "2021": {
+        "x": [
+          "Maschinen-/Fahrzeugbau",
+          "Elektroindustrie/Instrumententechnik",
+          "Pharma/Chemie/Kunststoff",
+          "Software/Datenverarbeitung",
+          "restliche Branchen"
+        ],
+        "y": [
+          18.4,
+          20.8,
+          25.0,
+          12.3,
+          42.0
+        ]
+      }
+    },
+    "de": {
+      "2012": {
+        "x": [
+          "Maschinen-/Fahrzeugbau",
+          "Elektroindustrie/Instrumententechnik",
+          "Pharma/Chemie/Kunststoff",
+          "Software/Datenverarbeitung",
+          "restliche Branchen"
+        ],
+        "y": [
+          49.9,
+          16.0,
+          15.2,
+          5.2,
+          13.8
+        ]
+      },
+      "2021": {
+        "x": [
+          "Maschinen-/Fahrzeugbau",
+          "Elektroindustrie/Instrumententechnik",
+          "Pharma/Chemie/Kunststoff",
+          "Software/Datenverarbeitung",
+          "restliche Branchen"
+        ],
+        "y": [
+          44.9,
+          15.0,
+          14.1,
+          9.1,
+          16.9
+        ]
+      }
+    }
+  }
 
 n = 20
 x = np.random.rand(n)
@@ -158,8 +208,8 @@ class ConfigImporter:
             plot_type = plot_config_custom["plot_type"]
             plot_config_default = config_default[plot_type]
 
-            self.override_values(plot_config_default, plot_config_custom)
-            config_result[plot_name] = plot_config_default
+            overwritten_config = self.override_values(plot_config_default, plot_config_custom)
+            config_result[plot_name] = overwritten_config
 
         return config_result
 
@@ -186,31 +236,45 @@ class ConfigImporter:
         :param default_config: dict, default configuration for a plot type
         :param custom_config: dict, custom configuration for a plot
         """
+
+        overwritten_config = default_config.copy()
         for key, value in custom_config.items():
-            if isinstance(value, dict) and key in default_config and isinstance(default_config[key], dict):
-                self.override_values(default_config[key], value)
+            if isinstance(value, dict) and key in overwritten_config and isinstance(default_config[key], dict):
+                self.override_values(overwritten_config[key], value)
             else:
-                default_config[key] = value
+                overwritten_config[key] = value
+        return overwritten_config
 
 
-# TODO: For now this functions is obsolete but it might be useful in the future
-def create_app():
-    return
-
-def get_pizza_chart():
+def get_fue_chart():
     config_importer = ConfigImporter()
     config = config_importer.get_config()
 
     plotter_factory = PlotterFactory()
 
-    pie_plotter = plotter_factory.create_plotter("pie_interactive", pie_data_2, config["pie_custom"])
+    pie_plotter = plotter_factory.create_plotter("pie_interactive", pie_data_2, config["donut_fue"])
     pie_plotter.generate()
 
-    pizza_chart = FlexBox(*[pie_plotter.plot["ber"], pie_plotter.plot["de"],
+    fue_chart = FlexBox(*[pie_plotter.plot["ber"], pie_plotter.plot["de"],
                             pie_plotter.filters_single_choice, pie_plotter.filters_single_choice_highlight],
                           flex_direction='row', flex_wrap='wrap', justify_content='space-between')
 
-    return pizza_chart.servable()
+    return fue_chart.servable()
+
+def get_shares_chart():
+    config_importer = ConfigImporter()
+    config = config_importer.get_config()
+
+    plotter_factory = PlotterFactory()
+
+    pie_plotter = plotter_factory.create_plotter("pie_interactive", shares_data, config["donut_shares"])
+    pie_plotter.generate()
+
+    shares_chart = FlexBox(*[pie_plotter.plot["ber"], pie_plotter.plot["de"],
+                            pie_plotter.filters_single_choice, pie_plotter.filters_single_choice_highlight],
+                          flex_direction='row', flex_wrap='wrap', justify_content='space-between')
+
+    return shares_chart.servable()
 
 
 def get_base_chart():

--- a/app/sliders/pn_app.py
+++ b/app/sliders/pn_app.py
@@ -16,26 +16,80 @@ pie_data = {
 
 pie_data_2 = {
     "ber": {
-        "2010": {
-            "x": ["wirtschaft", "hochschulen", "staat"],
-            "y": [952, 380, 803]
-        },
-        "2020": {
-            "x": ["wirtschaft", "hochschulen", "staat"],
-            "y": [552, 280, 703]
-        },
+      "2011": {
+        "x": [
+          "Wirtschaft",
+          "Hochschulen",
+          "Staat"
+        ],
+        "y": [
+          1402.0,
+          950.0,
+          1257.0
+        ]
+      },
+      "2020": {
+        "x": [
+          "Wirtschaft",
+          "Hochschulen",
+          "Staat"
+        ],
+        "y": [
+          1402.0,
+          950.0,
+          1257.0
+        ]
+      }
     },
     "de": {
-        "2010": {
-            "x": ["wirtschaft", "hochschulen", "staat"],
-            "y": [1952, 1380, 1803]
-        },
-        "2020": {
-            "x": ["wirtschaft", "hochschulen", "staat"],
-            "y": [1552, 1280, 1703]
-        },
-    },
-}
+      "2011": {
+        "x": [
+          "Wirtschaft",
+          "Hochschulen",
+          "Staat"
+        ],
+        "y": [
+          51077.0,
+          13518.0,
+          10974.0
+        ]
+      },
+      "2020": {
+        "x": [
+          "Wirtschaft",
+          "Hochschulen",
+          "Staat"
+        ],
+        "y": [
+          51077.0,
+          13518.0,
+          10974.0
+        ]
+      }
+    }
+  }
+# pie_data_2 = {
+#     "ber": {
+#         "2010": {
+#             "x": ["wirtschaft", "hochschulen", "staat"],
+#             "y": [952, 380, 803]
+#         },
+#         "2020": {
+#             "x": ["wirtschaft", "hochschulen", "staat"],
+#             "y": [552, 280, 703]
+#         },
+#     },
+#     "de": {
+#         "2010": {
+#             "x": ["wirtschaft", "hochschulen", "staat"],
+#             "y": [1952, 1380, 1803]
+#         },
+#         "2020": {
+#             "x": ["wirtschaft", "hochschulen", "staat"],
+#             "y": [1552, 1280, 1703]
+#         },
+#     },
+# }
 
 n = 20
 x = np.random.rand(n)

--- a/app/sliders/pn_app.py
+++ b/app/sliders/pn_app.py
@@ -5,6 +5,8 @@ import numpy as np
 from panel.layout.gridstack import GridSpec
 from panel.layout.flex import FlexBox
 
+from app.sliders.config_importer import ConfigImporter
+
 from .plotter import PlotterFactory
 # import logging
 # logging.basicConfig(level=logging.INFO)
@@ -187,63 +189,6 @@ interactive_line_data = {
 bar_data = {"x": ["A", "B", "C", "D"],
             "y": [15, 40, 25, 30]
 }
-
-
-# TODO: Move ConfigImporter to another module
-class ConfigImporter:
-    def get_config(self):
-        """
-        Create a config dictionary based on default and custom values.
-
-        :return: dict, resulting configuration file
-        """
-        # Load config files
-        config_default = self.load_config_file("config_default.yaml")
-        config_custom = self.load_config_file("config_custom.yaml")
-
-        config_result = {}
-        # Override default values with custom values for each plot
-        for plot_name in config_custom:
-            plot_config_custom = config_custom[plot_name]
-            plot_type = plot_config_custom["plot_type"]
-            plot_config_default = config_default[plot_type]
-
-            overwritten_config = self.override_values(plot_config_default, plot_config_custom)
-            config_result[plot_name] = overwritten_config
-
-        return config_result
-
-    def load_config_file(self, filename):
-        """
-        Load a config file.
-
-        :param filename: str, name of the YAML config file
-        :return: dict, containing config settings
-        """
-        current_dir = os.path.dirname(__file__)
-        config_path = os.path.join(current_dir, filename)
-
-        with open(config_path, "r") as f:
-            config = yaml.load(f, Loader=yaml.FullLoader)
-
-        return config
-
-    def override_values(self, default_config, custom_config):
-        """
-        Override default values with custom values of a plot configuration.
-        Implemented as a recursive function.
-
-        :param default_config: dict, default configuration for a plot type
-        :param custom_config: dict, custom configuration for a plot
-        """
-
-        overwritten_config = default_config.copy()
-        for key, value in custom_config.items():
-            if isinstance(value, dict) and key in overwritten_config and isinstance(default_config[key], dict):
-                self.override_values(overwritten_config[key], value)
-            else:
-                overwritten_config[key] = value
-        return overwritten_config
 
 
 def get_fue_chart():

--- a/app/sliders/pn_app.py
+++ b/app/sliders/pn_app.py
@@ -1,12 +1,8 @@
-import os
-import yaml
-
 import numpy as np
 from panel.layout.gridstack import GridSpec
 from panel.layout.flex import FlexBox
 
-from app.sliders.config_importer import ConfigImporter
-
+from .config_importer import ConfigImporter
 from .plotter import PlotterFactory
 # import logging
 # logging.basicConfig(level=logging.INFO)

--- a/app/sliders/pn_app.py
+++ b/app/sliders/pn_app.py
@@ -7,137 +7,29 @@ from .plotter import PlotterFactory
 # import logging
 # logging.basicConfig(level=logging.INFO)
 
+import os
+import json
+
+def import_data(chart_id):
+    """
+    Main method of the class.
+    Import the data from a generated JSON file.
+    """
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    outfile_path = os.path.join(current_dir, "../../data/outfile.json")
+
+    with open(outfile_path, 'r') as f:
+        chart_data = json.load(f)
+  
+    return chart_data[chart_id]
+
+
 
 # Create some random data - TODO: To be deleted later
 pie_data = {
     "x": ["United States", "United Kingdom", "Japan", "China", "Germany"],
     "y": [157, 93, 89, 63, 44]
 }
-
-pie_data_2 = {
-    "ber": {
-      "2011": {
-        "x": [
-          "Wirtschaft",
-          "Hochschulen",
-          "Staat"
-        ],
-        "y": [
-          1402.0,
-          950.0,
-          1257.0
-        ]
-      },
-      "2020": {
-        "x": [
-          "Wirtschaft",
-          "Hochschulen",
-          "Staat"
-        ],
-        "y": [
-          1402.0,
-          950.0,
-          1257.0
-        ]
-      }
-    },
-    "de": {
-      "2011": {
-        "x": [
-          "Wirtschaft",
-          "Hochschulen",
-          "Staat"
-        ],
-        "y": [
-          51077.0,
-          13518.0,
-          10974.0
-        ]
-      },
-      "2020": {
-        "x": [
-          "Wirtschaft",
-          "Hochschulen",
-          "Staat"
-        ],
-        "y": [
-          51077.0,
-          13518.0,
-          10974.0
-        ]
-      }
-    }
-  }
-shares_data = {
-    "ber": {
-      "2012": {
-        "x": [
-          "Maschinen-/Fahrzeugbau",
-          "Elektroindustrie/Instrumententechnik",
-          "Pharma/Chemie/Kunststoff",
-          "Software/Datenverarbeitung",
-          "restliche Branchen"
-        ],
-        "y": [
-          14.1,
-          30.4,
-          31.0,
-          7.2,
-          31.4
-        ]
-      },
-      "2021": {
-        "x": [
-          "Maschinen-/Fahrzeugbau",
-          "Elektroindustrie/Instrumententechnik",
-          "Pharma/Chemie/Kunststoff",
-          "Software/Datenverarbeitung",
-          "restliche Branchen"
-        ],
-        "y": [
-          18.4,
-          20.8,
-          25.0,
-          12.3,
-          42.0
-        ]
-      }
-    },
-    "de": {
-      "2012": {
-        "x": [
-          "Maschinen-/Fahrzeugbau",
-          "Elektroindustrie/Instrumententechnik",
-          "Pharma/Chemie/Kunststoff",
-          "Software/Datenverarbeitung",
-          "restliche Branchen"
-        ],
-        "y": [
-          49.9,
-          16.0,
-          15.2,
-          5.2,
-          13.8
-        ]
-      },
-      "2021": {
-        "x": [
-          "Maschinen-/Fahrzeugbau",
-          "Elektroindustrie/Instrumententechnik",
-          "Pharma/Chemie/Kunststoff",
-          "Software/Datenverarbeitung",
-          "restliche Branchen"
-        ],
-        "y": [
-          44.9,
-          15.0,
-          14.1,
-          9.1,
-          16.9
-        ]
-      }
-    }
-  }
 
 n = 20
 x = np.random.rand(n)
@@ -188,12 +80,13 @@ bar_data = {"x": ["A", "B", "C", "D"],
 
 
 def get_fue_chart():
+    chart_data = import_data("fue-expenses")
     config_importer = ConfigImporter()
     config = config_importer.get_config()
 
     plotter_factory = PlotterFactory()
 
-    pie_plotter = plotter_factory.create_plotter("pie_interactive", pie_data_2, config["donut_fue"])
+    pie_plotter = plotter_factory.create_plotter("pie_interactive", chart_data, config["donut_fue"])
     pie_plotter.generate()
 
     fue_chart = FlexBox(*[pie_plotter.plot["ber"], pie_plotter.plot["de"],
@@ -203,12 +96,13 @@ def get_fue_chart():
     return fue_chart.servable()
 
 def get_shares_chart():
+    chart_data = import_data("shares")
     config_importer = ConfigImporter()
     config = config_importer.get_config()
 
     plotter_factory = PlotterFactory()
 
-    pie_plotter = plotter_factory.create_plotter("pie_interactive", shares_data, config["donut_shares"])
+    pie_plotter = plotter_factory.create_plotter("pie_interactive", chart_data, config["donut_shares"])
     pie_plotter.generate()
 
     shares_chart = FlexBox(*[pie_plotter.plot["ber"], pie_plotter.plot["de"],
@@ -219,6 +113,8 @@ def get_shares_chart():
 
 
 def get_base_chart():
+    # TODO: Import real data and adjust plotter accordingly
+    chart_data = import_data("base")
     config_importer = ConfigImporter()
     config = config_importer.get_config()
 

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -690,20 +690,16 @@ video {
   max-width: 56rem;
 }
 
+.max-w-5xl {
+  max-width: 64rem;
+}
+
 .max-w-full {
   max-width: 100%;
 }
 
 .max-w-hero {
   max-width: var(--width-hero);
-}
-
-.max-w-6xl {
-  max-width: 72rem;
-}
-
-.max-w-5xl {
-  max-width: 64rem;
 }
 
 .-translate-x-1\/2 {
@@ -803,19 +799,14 @@ video {
   border-color: rgb(73 93 165 / var(--tw-border-opacity));
 }
 
-.border-white {
-  --tw-border-opacity: 1;
-  border-color: rgb(255 255 255 / var(--tw-border-opacity));
-}
-
 .border-corporate-gray-20 {
   --tw-border-opacity: 1;
   border-color: rgb(218 218 218 / var(--tw-border-opacity));
 }
 
-.border-t-corporate-gray-20 {
+.border-white {
   --tw-border-opacity: 1;
-  border-top-color: rgb(218 218 218 / var(--tw-border-opacity));
+  border-color: rgb(255 255 255 / var(--tw-border-opacity));
 }
 
 .bg-corporate-blue {
@@ -858,17 +849,16 @@ video {
   padding-bottom: 2rem;
 }
 
-.py-2 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-}
-
 .pb-2 {
   padding-bottom: 0.5rem;
 }
 
 .pb-6 {
   padding-bottom: 1.5rem;
+}
+
+.pb-8 {
+  padding-bottom: 2rem;
 }
 
 .pt-10 {
@@ -885,14 +875,6 @@ video {
 
 .pt-7 {
   padding-top: 1.75rem;
-}
-
-.pt-8 {
-  padding-top: 2rem;
-}
-
-.pb-8 {
-  padding-bottom: 2rem;
 }
 
 .text-left {


### PR DESCRIPTION
The importer.py now has two more parsers:  

- FuE-Ausgaben
- Anteile-Branchen
The outfile.json now includes the base chart as well as the fue-chart data and shares-chart data.

I also replaced the dummy data from pn_app.py with the extracted data for both of them and plotted the charts in the app.

I also had to alter the override_values method from the ConfigImporter Class, since it wasn't possible to overwrite config_default multiple times without conflicts. 