### PR TITLE
chore: add Tailwind build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "scripts": {
-        "dev:tailwind": "tailwindcss -i app/styles/main.css -o app/static/css/main.css --watch"
+        "dev:tailwind": "tailwindcss -i app/styles/main.css -o app/static/css/main.css --watch",
+        "build": "tailwindcss -i app/styles/main.css -o app/static/css/main.css --minify"
     },
     "devDependencies": {
         "prettier": "^3.0.3",


### PR DESCRIPTION
Adds a npm script `build` that executes Tailwind with its `--minify` flag to create production output. This is part of the release preparation.