### PR TITLE
refactor: restructure content setup to allow for multiple headers and text-only paragraphs

### DIFF
--- a/app/locales/de.json
+++ b/app/locales/de.json
@@ -17,8 +17,7 @@
     "closeNav": "Inhaltsverzeichnis schließen",
     "internalLink": "Interner Link",
     "label": "Inhaltsverzeichnis",
-    "scrollTop": "Zum Start der Seite gehen",
-    "subHeader_1": "Allgemeine Zahlen"
+    "scrollTop": "Zum Start der Seite gehen"
   },
   "chartToggle": {
     "ariaLabel": "Schalte um zwischen Berlin und Deutschland",
@@ -26,6 +25,10 @@
     "germany": "Deutschland"
   },
   "sections": [
+    {
+      "type": "header",
+      "title": "Allgemeine Zahlen"
+    },
     {
       "type": "quote",
       "quote": "Die <strong>Innovationserhebung 2022</strong> widmet sich in gewohnter Weise der Auswertung der durch das Zentrum für Europäische Wirtschaftsforschung (ZEW) erhobenen Daten zum Innovationsverhalten Berlins. <br><br>Die Innovationserhebung Berlin wird zeitgleich mit der deutschen Innovationserhebung durchgeführt und nimmt Industrieunternehmen sowie Unternehmen aus dem Bereich wissensintensive Dienstleistungen über das letzte Jahrzehnt in den Blick."

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -592,16 +592,8 @@ video {
   margin-right: auto;
 }
 
-.mb-16 {
-  margin-bottom: 4rem;
-}
-
 .mb-2 {
   margin-bottom: 0.5rem;
-}
-
-.mb-4 {
-  margin-bottom: 1rem;
 }
 
 .mb-6 {
@@ -780,6 +772,10 @@ video {
 
 .justify-between {
   justify-content: space-between;
+}
+
+.gap-16 {
+  gap: 4rem;
 }
 
 .gap-2 {

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -592,11 +592,6 @@ video {
   margin-right: auto;
 }
 
-.mx-mobile {
-  margin-left: 1.5rem;
-  margin-right: 1.5rem;
-}
-
 .mb-16 {
   margin-bottom: 4rem;
 }
@@ -787,6 +782,10 @@ video {
   justify-content: space-between;
 }
 
+.gap-2 {
+  gap: 0.5rem;
+}
+
 .self-end {
   align-self: flex-end;
 }
@@ -885,6 +884,10 @@ video {
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
 
+.p-mobile {
+  padding: 1.5rem;
+}
+
 .\!px-4 {
   padding-left: 1rem !important;
   padding-right: 1rem !important;
@@ -951,10 +954,6 @@ video {
 
 .pt-4 {
   padding-top: 1rem;
-}
-
-.pt-7 {
-  padding-top: 1.75rem;
 }
 
 .text-left {

--- a/app/templates/components/chart-toggle.html
+++ b/app/templates/components/chart-toggle.html
@@ -1,26 +1,32 @@
-<p class="font-source">{{ chart.description | safe }}</p>
-<p class="text-corporate-blue text-center text-h2 mt-14">
-  {{ chart.toggleText }}
-  <select
-    id="{{ chart.id }}_toggle"
-    class="bg-white font-bold border-b-2 border-corporate-blue inline cursor-pointer hover:bg-light-gray"
-    aria-controls="{{ chart.id }}_ber {{ chart.id }}_ger"
-    aria-label="{{ translations.chartToggle.ariaLabel }}"
-  >
-    <option value="{{ chart.id }}_ber">
-      {{ translations.chartToggle.berlin }}
-    </option>
-    <option value="{{ chart.id }}_ger">
-      {{ translations.chartToggle.germany }}
-    </option>
-  </select>
-</p>
-<div id="{{ section_id }}_ber" class="mb-16">
-  <figure>
-    {{ request.app.extra[chart.id]|safe }}
-    <figcaption class="text-sm">
-      {{ section_title }} {{ translations.general.for }}
-      {{ translations.chartToggle.berlin }}
-    </figcaption>
-  </figure>
+<div>
+  <p class="font-source">{{ chart.description | safe }}</p>
+  {% if chart.id %}
+    {% if chart.toggleText %}
+      <p class="text-corporate-blue text-center text-h2 mt-14">
+        {{ chart.toggleText }}
+        <select
+          id="{{ chart.id }}_toggle"
+          class="bg-white font-bold border-b-2 border-corporate-blue inline cursor-pointer hover:bg-light-gray"
+          aria-controls="{{ chart.id }}_ber {{ chart.id }}_ger"
+          aria-label="{{ translations.chartToggle.ariaLabel }}"
+        >
+          <option value="{{ chart.id }}_ber">
+            {{ translations.chartToggle.berlin }}
+          </option>
+          <option value="{{ chart.id }}_ger">
+            {{ translations.chartToggle.germany }}
+          </option>
+        </select>
+      </p>
+    {% endif %}
+    <div id="{{ section_id }}_ber">
+      <figure>
+        {{ request.app.extra[chart.id]|safe }}
+        <figcaption class="text-sm">
+          {{ section_title }} {{ translations.general.for }}
+          {{ translations.chartToggle.berlin }}
+        </figcaption>
+      </figure>
+    </div>
+  {% endif %}
 </div>

--- a/app/templates/components/navigation/nav-desktop.html
+++ b/app/templates/components/navigation/nav-desktop.html
@@ -1,10 +1,9 @@
-<div class="border-b border-corporate-blue-light mx-mobile pt-7 pb-2 mb-6">
-  <span class="font-bold">{{ translations.nav.subHeader_1 }}</span>
-</div>
-<ul id="accordion-list" class="h-full px-mobile overflow-scroll max-w-hero">
+<ul id="accordion-list" class="h-full p-mobile overflow-scroll max-w-hero">
   {% for section in translations.get("sections", []) %}
     {% with section=section %}
-      {% if section.id %}
+      {% if section.type == "header" %}
+        {% include "components/navigation/nav-header.html" %}
+      {% elif section.id %}
         {% include "components/navigation/nav-link.html" %}
       {% endif %}
     {% endwith %}

--- a/app/templates/components/navigation/nav-header.html
+++ b/app/templates/components/navigation/nav-header.html
@@ -1,0 +1,1 @@
+<li class="pb-2 mb-6 border-b border-corporate-blue-light font-bold">{{ section.title }}</li>

--- a/app/templates/components/navigation/nav-link.html
+++ b/app/templates/components/navigation/nav-link.html
@@ -3,10 +3,10 @@
   data-section-id="{{ section.id }}"
   data-toggle="click-nav-link"
 >
-  <a class=" flex justify-between" href="#{{ section.id }}">
+  <a class="flex justify-between gap-2" href="#{{ section.id }}">
     <span>{{ section.title }}</span>
     <img
-      class="w-4 mr-6"
+      class="w-4"
       src="{{ url_for('static', path='images/arrow-right.svg') }}"
       alt="{{ translations.nav.internalLink }}"
     />

--- a/app/templates/components/navigation/nav-mobile.html
+++ b/app/templates/components/navigation/nav-mobile.html
@@ -37,18 +37,15 @@
   </div>
   <div
     id="accordion-list"
-    class="h-full max-h-0 px-mobile overflow-scroll max-w-4xl mx-auto tablet:px-16 transition-all duration-300 {% if false %}max-h-screen{% endif %}"
+    class="h-full max-h-0 overflow-scroll max-w-4xl mx-auto tablet:px-16 transition-all duration-300 {% if false %}max-h-screen{% endif %}"
   >
-    <div class="border-b border-corporate-blue-light pt-4 pb-2 mb-6">
-      <span class="font-bold">{{ translations.nav.subHeader_1 }}</span>
-    </div>
-    <ul>
+    <ul class="p-mobile">
       {% for section in translations.sections %}
-        {% with section=section %}
-          {% if section.id %}
-            {% include "components/navigation/nav-link.html" %}
-          {% endif %}
-        {% endwith %}
+        {% if section.type == "header" %}
+          {% include "components/navigation/nav-header.html" %}
+        {% elif section.id %}
+          {% include "components/navigation/nav-link.html" %}
+        {% endif %}
       {% endfor %}
     </ul>
   </div>

--- a/app/templates/components/section.html
+++ b/app/templates/components/section.html
@@ -1,10 +1,8 @@
 {% set section_id = section.id %}
-{% set section_type = section.type %}
 <section class="py-8 border-t border-corporate-gray-20 first-of-type:border-hidden" id="{{ section_id }}">
-  {% if section_type == "quote" %}
-    {% set section = section %}
+  {% if section.type == "quote" %}
     {% include "components/quote-section.html" %}
-  {% else %}
+  {% elif section.type == "chart" %}
   <div class="desktop:px-12">
     <h2 class="text-sm font-bold mt-0 mb-2 text-corporate-blue pb-10">
       {{ section.title }}

--- a/app/templates/components/section.html
+++ b/app/templates/components/section.html
@@ -16,6 +16,6 @@
         {% include "components/chart-toggle.html" %}
       {% endfor %}
     </div>
-    {% endif %}
-  </divclass>
+  </div>
+  {% endif %}
 </section>

--- a/app/templates/components/section.html
+++ b/app/templates/components/section.html
@@ -8,7 +8,7 @@
       {{ section.title }}
     </h2>
     <h3 class="text-corporate-blue text-2xl font-thin leading-10 pb-10">{{ section.disclaimer }}</h3>
-    <div class="mb-4">
+    <div class="flex flex-col gap-16">
       {% set charts = section.charts %}
       {% for chart in charts %}
         {% include "components/chart-toggle.html" %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -23,12 +23,9 @@
       <div class="w-full max-w-5xl mx-auto">
         <span id="nav-visible-anchor"></span>
         {% for section in translations.get("sections", []) %}
-          {%
-            with
-            section=section
-          %}
+          {% if section.type != "header" %}
             {% include "components/section.html" %}
-          {% endwith %}
+          {% endif %}
         {% endfor %}
       </div>
     </div>


### PR DESCRIPTION
This restructures our locales/content setup a bit to match Marco’s requirements:

### Multiple headers

We can now use multiple headers (instead of just one hard-coded `subHeader_1`) with the new `"type": "header"` section.

**Example:**
```jsonc
  "sections": [
    {
      "type": "header",
      "title": "Allgemeine Zahlen"
    },
    // ...
  ]
```

### Paragraphs without charts

New paragraphs can be added inside `charts` without each needing their own chart (`"id"` and `"toggleText"` are optional now).

ℹ️ Ideally, we would now rename `"charts"` to something like `"content"` to reflect this. But, to avoid too many merge conflicts, I’d suggest to keep this for now and clean up the names later when the data model is stable.

**Example:**

```jsonc
    {
      "type": "chart",
      "id": "section_2",
      "title": "II. Anteile der Wirtschaft an der gesamten Forschung",
      "disclaimer": "Weiterhin kommen gute zwei Drittel der Mittel aus öffentlicher Hand.",
      "charts": [
        {
          "id": "fue_pie_interactive",
          "description": "Some long description",
          "toggleText": "Zusammensetzung der FuE-Ausgaben in "
        },
        {
          "description": "This is a new paragraph below the chart, without a new chart!"
        }
      ]
    },
```

### Some smaller fixes in HTML templates

- There was an invalid `</divclass>` and a wrongly-nested `{% endif %}`
- There was no space between the nav item text and the arrow icon yet
- Some padding + margin cleanup

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205937783244059