### PR TITLE
Feat/location toggle

### DIFF
--- a/app/sliders/plotter.py
+++ b/app/sliders/plotter.py
@@ -119,7 +119,8 @@ class BarPlotter(Plotter):
 
     def create_plot(self):
         # Create the figure
-        self.plot = figure(x_range=self.fitted_data.data["x"], **self.config["general"])
+        self.plot = figure(
+            x_range=self.fitted_data.data["x"], **self.config["general"])
 
         # Add vertical bars to the figure
         self.plot.vbar(x="x", top="y", source=self.fitted_data, color="color",
@@ -142,10 +143,12 @@ class InteractiveBarPlotter(InteractivePlotter):
                 for choice_2 in self.config["filters"]["single_choice_2"]:
                     x_values = self.raw_data[code][choice][choice_2]["x"]
                     # Define color palette
-                    self.raw_data[code][choice][choice_2]["color"] = Category20[len(x_values)]
+                    self.raw_data[code][choice][choice_2]["color"] = Category20[len(
+                        x_values)]
                     # Split long x-axis in more than one line
                     for i, label in enumerate(x_values):
-                        self.raw_data[code][choice][choice_2]["x"][i] = "/\n".join(label.split("/"))
+                        self.raw_data[code][choice][choice_2]["x"][i] = "/\n".join(
+                            label.split("/"))
 
         self.fitted_data = {}
         for code in self.config["plot_codes"]:
@@ -160,19 +163,21 @@ class InteractiveBarPlotter(InteractivePlotter):
 
         for code in self.config["plot_codes"]:
             # Create the figure
-            plot = figure(x_range=self.fitted_data[code].data["x"], **self.config["general"])
+            plot = figure(
+                x_range=self.fitted_data[code].data["x"], **self.config["general"])
 
             # Stretch to full width.
             plot.sizing_mode = "scale_width"
             plot.width_policy = "max"
 
             # Add vertical bars to the figure
-            plot.vbar(x="x", top="y", source=self.fitted_data[code], color="color", **self.config["vbar"])
+            plot.vbar(
+                x="x", top="y", source=self.fitted_data[code], color="color", **self.config["vbar"])
 
             # Rotate x-axis labels
             plot.xaxis.major_label_orientation = pi/2
 
-            #Fixed line-height for tick-labels
+            # Fixed line-height for tick-labels
             plot.xaxis.axis_label_text_line_height = 1
 
             self.plot[code] = plot
@@ -223,8 +228,10 @@ class BubblePlotter(Plotter):
         self.plot.width_policy = "max"
 
         # Add circles to the plot
-        mapper = linear_cmap(field_name="color", palette=Category20[20], low=0, high=20)
-        self.plot.circle(x="x", y="y", size="z", color=mapper, source=self.fitted_data, legend_group="labels")
+        mapper = linear_cmap(field_name="color",
+                             palette=Category20[20], low=0, high=20)
+        self.plot.circle(x="x", y="y", size="z", color=mapper,
+                         source=self.fitted_data, legend_group="labels")
 
         # Set the position of the legend
         self.plot.add_layout(self.plot.legend[0], "right")
@@ -257,7 +264,8 @@ class InteractiveBubblePlotter(InteractivePlotter):
         self.fitted_data = {}
 
         for code in self.config["plot_codes"]:
-            single_choice_dict = self.raw_data[code][self.config["filters"]["single_choice_default"]]
+            single_choice_dict = self.raw_data[code][self.config["filters"]
+                                                     ["single_choice_default"]]
             source = ColumnDataSource(data={"x": single_choice_dict["x"],
                                             "y": single_choice_dict["y"],
                                             "z": self.scale_values(single_choice_dict["z"]),
@@ -283,8 +291,10 @@ class InteractiveBubblePlotter(InteractivePlotter):
                           y_range=[min(y_range), max(y_range)])
 
             # Add circles to the plot
-            mapper = linear_cmap(field_name="color", palette=Category20[20], low=0, high=20)
-            plot.circle(x="x", y="y", size="z", color=mapper, source=self.fitted_data[code], legend_group="labels")
+            mapper = linear_cmap(field_name="color",
+                                 palette=Category20[20], low=0, high=20)
+            plot.circle(x="x", y="y", size="z", color=mapper,
+                        source=self.fitted_data[code], legend_group="labels")
 
             # Set the position of the legend
             plot.add_layout(plot.legend[0], "right")
@@ -342,7 +352,8 @@ class LinePlotter(Plotter):
         self.plot.width_policy = "max"
 
         # Add a line glyph to the figure
-        self.plot.line(x="x", y="y", source=self.fitted_data, **self.config["line"])
+        self.plot.line(x="x", y="y", source=self.fitted_data,
+                       **self.config["line"])
 
         # Show legends
         self.plot.legend.title = self.config["legend_title"]
@@ -361,7 +372,8 @@ class InteractiveLinePlotter(InteractivePlotter):
 
         for code in self.config["plot_codes"]:
             # Extract data using the single choice filters
-            single_choice_dict = (self.raw_data[code][self.config["filters"]["single_choice_default"]])
+            single_choice_dict = (
+                self.raw_data[code][self.config["filters"]["single_choice_default"]])
 
             # Get a subset of the lines selected with the multi choice filters
             selected_lines = ["x"] + self.config["filters"]["multi_choice"]
@@ -380,7 +392,8 @@ class InteractiveLinePlotter(InteractivePlotter):
 
         for code in self.config["plot_codes"]:
             # Create a Bokeh figure
-            max_value = self.get_max_value(code, self.config["filters"]["single_choice_default"])
+            max_value = self.get_max_value(
+                code, self.config["filters"]["single_choice_default"])
             self.plot[code] = figure(**self.config["general"],
                                      x_range=[x_range[0], x_range[-1]],
                                      y_range=[0, max_value])
@@ -388,7 +401,7 @@ class InteractiveLinePlotter(InteractivePlotter):
             # Stretch to full width.
             self.plot[code].sizing_mode = "scale_width"
             self.plot[code].width_policy = "max"
-            
+
             # Configure labels in x and y axes
             self.plot[code].xaxis.ticker = x_range
             self.plot[code].yaxis.formatter.use_scientific = False
@@ -396,7 +409,8 @@ class InteractiveLinePlotter(InteractivePlotter):
             # Add lines to the plot
             colors = Category20[20]
             for i, line_name in enumerate(self.config["filters"]["multi_choice"]):
-                self.plot[code].line(x="x", y=line_name, source=self.fitted_data[code], color=colors[i], legend_label=line_name)
+                self.plot[code].line(
+                    x="x", y=line_name, source=self.fitted_data[code], color=colors[i], legend_label=line_name)
 
     def create_filters(self):
         self.filters_single_choice = panel.widgets.RadioBoxGroup(
@@ -436,7 +450,8 @@ class InteractiveLinePlotter(InteractivePlotter):
         :param event: an event object that triggers the update
         """
         for code in self.config["plot_codes"]:
-            max_value = self.get_max_value(code, self.filters_single_choice.value)
+            max_value = self.get_max_value(
+                code, self.filters_single_choice.value)
             self.plot[code].y_range.end = max_value
 
     def get_max_value(self, code, single_choice):
@@ -512,7 +527,8 @@ class InteractivePiePlotter(InteractivePlotter):
 
         for code in self.config["plot_codes"]:
             # Extract data using the single choice filters
-            single_choice_dict = (self.raw_data[code][self.config["filters"]["single_choice_default"]])
+            single_choice_dict = (
+                self.raw_data[code][self.config["filters"]["single_choice_default"]])
 
             # Get x and y values
             x_values = single_choice_dict["x"]
@@ -556,9 +572,11 @@ class InteractivePiePlotter(InteractivePlotter):
 
             # Add a label in the center
             highlight_category = self.config["filters"]["single_choice_highlight_default"]
-            highlight_category_trunkated = (highlight_category[:self.center_label_max_characters] + '..') if len(highlight_category) > self.center_label_max_characters else highlight_category
+            highlight_category_trunkated = (highlight_category[:self.center_label_max_characters] + '..') if len(
+                highlight_category) > self.center_label_max_characters else highlight_category
             for key, value, color in zip(self.raw_data[code][self.config["filters"]["single_choice_default"]]["x"],
-                                         self.raw_data[code][self.config["filters"]["single_choice_default"]]["y"],
+                                         self.raw_data[code][self.config["filters"]
+                                                             ["single_choice_default"]]["y"],
                                          self.fitted_data[code].data["color"]):
                 if key == highlight_category:
                     label_value = f"{str(int(value))} Mio €"
@@ -572,8 +590,8 @@ class InteractivePiePlotter(InteractivePlotter):
                 text=label_value,
                 text_align="center",
                 text_baseline="middle",
-                text_font_style = "bold",
-                y_offset = 10,
+                text_font_style="bold",
+                y_offset=10,
                 text_font_size="14pt",
             )
 
@@ -585,7 +603,7 @@ class InteractivePiePlotter(InteractivePlotter):
                 text=label_text,
                 text_align="center",
                 text_baseline="middle",
-                y_offset = -10,
+                y_offset=-10,
                 text_font_size="8pt",
             )
 
@@ -620,7 +638,7 @@ class InteractivePiePlotter(InteractivePlotter):
 
         # Create single choice filter
         self.filters_single_choice = panel.widgets.RadioButtonGroup(
-            name="Select unit", 
+            name="Select unit",
             options=self.config["filters"]["single_choice"],
             margin=(32, 0)
         )
@@ -631,12 +649,14 @@ class InteractivePiePlotter(InteractivePlotter):
 
         # Add interactivity
         self.filters_single_choice.param.watch(self.update_filters, "value")
-        self.filters_single_choice_highlight.param.watch(self.update_filters, "value")
+        self.filters_single_choice_highlight.param.watch(
+            self.update_filters, "value")
 
     def update_filters(self, event):
         for code in self.config["plot_codes"]:
             # Extract data using the single choice filters
-            single_choice_dict = (self.raw_data[code][self.filters_single_choice.value])
+            single_choice_dict = (
+                self.raw_data[code][self.filters_single_choice.value])
 
             # Get x and y values
             x_values = single_choice_dict["x"]
@@ -657,7 +677,8 @@ class InteractivePiePlotter(InteractivePlotter):
 
             # Update the center label to match the highlighted category
             highlight_category = self.filters_single_choice_highlight.value
-            highlight_category_trunkated = (highlight_category[:self.center_label_max_characters] + '..') if len(highlight_category) > self.center_label_max_characters else highlight_category
+            highlight_category_trunkated = (highlight_category[:self.center_label_max_characters] + '..') if len(
+                highlight_category) > self.center_label_max_characters else highlight_category
             for key, value, color in zip(self.raw_data[code][self.filters_single_choice.value]["x"],
                                          self.raw_data[code][self.filters_single_choice.value]["y"],
                                          colors):

--- a/app/sliders/pn_app.py
+++ b/app/sliders/pn_app.py
@@ -52,9 +52,6 @@ interactive_line_data = {
 with open("data/outfile.json", "r") as f:
     data = json.load(f)
 
-with open("locales/de.json", "r") as f:
-    content = json.load(f)
-
 # Load config
 config_importer = ConfigImporter()
 config = config_importer.get_config()
@@ -121,46 +118,53 @@ def get_base_chart():
 # TODO:
 #  Think if I can simplify some of the code below, there is a lot of duplicate
 #  Do we really need to use FlexBox AND GridSpec? Maybe we can just use one
+def create_update_chart(flex_obj, plotter):
+    def update_chart(event):
+        selected_location = event.new
+        flex_obj.__setitem__(1, plotter.plot[selected_location])
+    return update_chart
+
+
 chart_collection = {}
 
-plot_key = "fue_pie_interactive"
-plotter = plotters[plot_key]
-plotted_charts = {
-    'de': plotter.plot["de"],
-    'ber': plotter.plot["ber"],
-}
+# Can we wrap all this in a function so we can reuse plotter, toggle flex_obj variables in a smaller scope?
 
-location_toggle = Select(options={
+plot_key = "fue_pie_interactive"
+fue_plotter = plotters[plot_key]
+fue_location_toggle = Select(options={
     'Deutschland': 'de', 'Berlin': 'ber'}, value='de')
 
-
-flex_obj_1 = FlexBox(location_toggle,
-                     plotted_charts[location_toggle.value],
-                     plotter.filters_single_choice,
-                     plotter.filters_single_choice_highlight,
-                     flex_direction="column",
-                     align_items="center",
-                     sizing_mode="stretch_width")
-chart_collection[plot_key] = flex_obj_1
-
-
-def update_chart(event):
-    selected_location = event.new
-    flex_obj_1.__setitem__(1, plotted_charts[selected_location])
+flex_obj_fue = FlexBox(fue_location_toggle,
+                       fue_plotter.plot[fue_location_toggle.value],
+                       fue_plotter.filters_single_choice,
+                       fue_plotter.filters_single_choice_highlight,
+                       flex_direction="column",
+                       align_items="center",
+                       sizing_mode="stretch_width")
+chart_collection[plot_key] = flex_obj_fue
 
 
-location_toggle.param.watch(update_chart, 'value')
+fue_update_chart = create_update_chart(flex_obj_fue, fue_plotter)
+fue_location_toggle.param.watch(fue_update_chart, 'value')
+
+
+shares_location_toggle = Select(options={
+    'Deutschland': 'de', 'Berlin': 'ber'}, value='de')
 
 plot_key = "shares_pie_interactive"
-plotter = plotters[plot_key]
-flex_obj = FlexBox(plotter.plot["ber"],
-                   plotter.plot["de"],
-                   plotter.filters_single_choice,
-                   plotter.filters_single_choice_highlight,
-                   flex_direction="column",
-                   align_items="center",
-                   sizing_mode="stretch_width")
-chart_collection[plot_key] = flex_obj
+shares_plotter = plotters[plot_key]
+flex_obj_shares = FlexBox(shares_location_toggle,
+                          shares_plotter.plot[shares_location_toggle.value],
+                          shares_plotter.filters_single_choice,
+                          shares_plotter.filters_single_choice_highlight,
+                          flex_direction="column",
+                          align_items="center",
+                          sizing_mode="stretch_width")
+chart_collection[plot_key] = flex_obj_shares
+
+shares_update_chart = create_update_chart(flex_obj_shares, shares_plotter)
+shares_location_toggle.param.watch(shares_update_chart, 'value')
+
 
 plot_key = "growth_bubble"
 plotter = plotters[plot_key]

--- a/app/sliders/pn_app.py
+++ b/app/sliders/pn_app.py
@@ -1,7 +1,9 @@
 import json
+import param
 
 from panel.layout.gridstack import GridSpec
 from panel.layout.flex import FlexBox
+from panel.widgets import Select
 
 from .config_importer import ConfigImporter
 from .plotter import PlotterFactory
@@ -50,6 +52,9 @@ interactive_line_data = {
 with open("data/outfile.json", "r") as f:
     data = json.load(f)
 
+with open("locales/de.json", "r") as f:
+    content = json.load(f)
+
 # Load config
 config_importer = ConfigImporter()
 config = config_importer.get_config()
@@ -70,7 +75,8 @@ for plot_key in config:
         plot_data = data[plot_key]
 
     # TODO: Can refactor create_plotter() so I only need to pass the config as an argument
-    plotter = plotter_factory.create_plotter(config[plot_key]["plot_type"], plot_data, config[plot_key])
+    plotter = plotter_factory.create_plotter(
+        config[plot_key]["plot_type"], plot_data, config[plot_key])
     plotter.generate()
 
     plotters[plot_key] = plotter
@@ -83,15 +89,31 @@ def get_base_chart():
                                                               config["base_line_interactive"])
     interactive_line_plotter.generate()
 
-    line_plotter = plotter_factory.create_plotter("line", line_data, config["base_line_interactive"])
+    line_plotter = plotter_factory.create_plotter(
+        "line", line_data, config["base_line_interactive"])
     line_plotter.generate()
 
-    base_chart = GridSpec(sizing_mode="stretch_both", min_height=800)
+    select = Select(options={
+        'Deutschland': 'de', 'Berlin': 'ber'}, value='de')
 
-    base_chart[0:3, 0:2] = interactive_line_plotter.plot["ber"]
-    base_chart[3:6, 0:2] = interactive_line_plotter.plot["de"]
-    base_chart[6:7, 0:1] = interactive_line_plotter.filters_multi_choice
-    base_chart[6:7, 1:2] = interactive_line_plotter.filters_single_choice
+    plotted_base_charts = {
+        'de': interactive_line_plotter.plot['de'],
+        'ber': interactive_line_plotter.plot['ber'],
+    }
+
+    base_chart = GridSpec(sizing_mode="stretch_width", min_height=800)
+
+    base_chart[0:1, 0:1] = select
+    base_chart[1:8, 0:4] = plotted_base_charts[select.value]
+    base_chart[8:12, 0:2] = interactive_line_plotter.filters_multi_choice
+    base_chart[8:12, 2:4] = interactive_line_plotter.filters_single_choice
+
+    def update_chart(event):
+        selected_location = event.new
+        base_chart[1:8, 0:4] = None
+        base_chart[1:8, 0:4] = plotted_base_charts[selected_location]
+
+    select.param.watch(update_chart, 'value')
 
     return base_chart
 
@@ -103,15 +125,31 @@ chart_collection = {}
 
 plot_key = "fue_pie_interactive"
 plotter = plotters[plot_key]
+plotted_charts = {
+    'de': plotter.plot["de"],
+    'ber': plotter.plot["ber"],
+}
 
-flex_obj = FlexBox(plotter.plot["ber"],
-                   plotter.plot["de"],
-                   plotter.filters_single_choice,
-                   plotter.filters_single_choice_highlight,
-                   flex_direction="column",
-                   align_items="center",
-                   sizing_mode="stretch_width")
-chart_collection[plot_key] = flex_obj
+location_toggle = Select(options={
+    'Deutschland': 'de', 'Berlin': 'ber'}, value='de')
+
+
+flex_obj_1 = FlexBox(location_toggle,
+                     plotted_charts[location_toggle.value],
+                     plotter.filters_single_choice,
+                     plotter.filters_single_choice_highlight,
+                     flex_direction="column",
+                     align_items="center",
+                     sizing_mode="stretch_width")
+chart_collection[plot_key] = flex_obj_1
+
+
+def update_chart(event):
+    selected_location = event.new
+    flex_obj_1.__setitem__(1, plotted_charts[selected_location])
+
+
+location_toggle.param.watch(update_chart, 'value')
 
 plot_key = "shares_pie_interactive"
 plotter = plotters[plot_key]

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1264,6 +1264,7 @@ select.bk-input:hover {
 
 .bk-input-group {
   width: 180px;
+  margin: auto;
 }
 
 .first-of-type\:mt-0:first-of-type {

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -856,6 +856,10 @@ video {
   border-width: 1px !important;
 }
 
+.border-0 {
+  border-width: 0px;
+}
+
 .border-b {
   border-bottom-width: 1px;
 }
@@ -950,6 +954,11 @@ video {
   padding-right: 1.5rem;
 }
 
+.py-0 {
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
 .py-10 {
   padding-top: 2.5rem;
   padding-bottom: 2.5rem;
@@ -1019,6 +1028,10 @@ video {
 
 .text-\[18px\] {
   font-size: 18px;
+}
+
+.text-\[22px\] {
+  font-size: 22px;
 }
 
 .text-h1 {
@@ -1217,6 +1230,40 @@ body {
   background-color: rgb(255 255 255 / var(--tw-bg-opacity)) !important;
   --tw-text-opacity: 1 !important;
   color: rgb(30 55 145 / var(--tw-text-opacity)) !important;
+}
+
+.bk-panel-models-widgets-CustomSelect {
+  display: flex;
+  justify-content: center;
+}
+
+select.bk-input {
+  display: inline;
+  cursor: pointer;
+  border-radius: 0px;
+  border-width: 0px;
+  border-bottom-width: 2px;
+  --tw-border-opacity: 1;
+  border-color: rgb(30 55 145 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(246 246 246 / var(--tw-bg-opacity));
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  padding-right: 0px;
+  font-size: 22px;
+  font-weight: 700;
+  --tw-text-opacity: 1;
+  color: rgb(30 55 145 / var(--tw-text-opacity));
+}
+
+select.bk-input:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(235 236 240 / var(--tw-bg-opacity));
+}
+
+.bk-input-group {
+  width: 180px;
 }
 
 .first-of-type\:mt-0:first-of-type {

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -58,6 +58,17 @@ body {
   @apply !bg-white !text-corporate-blue;
 }
 
+.bk-panel-models-widgets-CustomSelect {
+  @apply flex justify-center;
+}
+select.bk-input {
+  @apply bg-page-background font-bold rounded-none border-0 border-b-2 py-0 border-corporate-blue text-[22px] text-corporate-blue inline cursor-pointer hover:bg-light-gray px-0;
+}
+
+.bk-input-group {
+  width: 180px;
+}
+
 
 @layer utilities {
   h1 {

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -67,6 +67,7 @@ select.bk-input {
 
 .bk-input-group {
   width: 180px;
+  margin: auto;
 }
 
 

--- a/app/templates/components/chart-toggle.html
+++ b/app/templates/components/chart-toggle.html
@@ -6,19 +6,6 @@
     {% if chart.toggleText %}
       <p class="text-corporate-blue text-center text-h2 mt-14">
         {{ chart.toggleText }}
-        <select
-          id="{{ chart.id }}_toggle"
-          class="bg-page-background font-bold rounded-none border-b-2 border-corporate-blue inline cursor-pointer hover:bg-light-gray"
-          aria-controls="{{ chart.id }}_ber {{ chart.id }}_ger"
-          aria-label="{{ translations.chartToggle.ariaLabel }}"
-        >
-          <option value="{{ chart.id }}_ber">
-            {{ translations.chartToggle.berlin }}
-          </option>
-          <option value="{{ chart.id }}_ger">
-            {{ translations.chartToggle.germany }}
-          </option>
-        </select>
       </p>
     {% endif %}
     <div id="{{ section.id }}_ber">


### PR DESCRIPTION
Here is a working implementation of the location toggle for the base and the first two donut charts. 
it, however, breaks the logic of overwriting the plotter / flex_object and so on variables. I wonder, I we can wrap everything in a generic function. Let's discuss this.
I would also like to generate the "toggleText" in python: 
<img width="432" alt="image" src="https://github.com/technologiestiftung/innovationserhebung/assets/50147356/6f8e44cd-aaf3-4e5c-837d-2a0f2f3004ce">
